### PR TITLE
feat: add date/datetime format

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.modelmapper:modelmapper:3.1.1'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'org.postgresql:postgresql'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/src/main/java/com/example/order/config/JacksonConfig.java
+++ b/src/main/java/com/example/order/config/JacksonConfig.java
@@ -1,20 +1,41 @@
 package com.example.order.config;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import java.time.format.DateTimeFormatter;
+import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class JacksonConfig {
 
+	private static final String DATE_FORMAT = "yyyy-MM-dd";
+
+	private static final String DATE_TIME_FORMAT = "yyyy-MM-dd HH:mm:ss";
+
 	@Bean
-	public ObjectMapper objectMapper() {
-		return new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-			.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
-			.setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
+	public Jackson2ObjectMapperBuilderCustomizer jackson2ObjectMapperBuilderCustomizer() {
+		return builder -> {
+			// Configure date/time formats
+			DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern(DATE_FORMAT);
+			DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern(DATE_TIME_FORMAT);
+
+			builder.modules(new JavaTimeModule()); // Register the JSR-310 module
+			builder.propertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
+			builder.failOnUnknownProperties(false);
+			builder.failOnEmptyBeans(false);
+
+			// Register custom date/time serializers and deserializers
+			builder.deserializers(new LocalDateDeserializer(dateFormatter));
+			builder.deserializers(new LocalDateTimeDeserializer(dateTimeFormatter));
+			builder.serializers(new LocalDateSerializer(dateFormatter));
+			builder.serializers(new LocalDateTimeSerializer(dateTimeFormatter));
+		};
 	}
 
 }

--- a/src/main/java/com/example/order/domain/model/BaseEntityAudit.java
+++ b/src/main/java/com/example/order/domain/model/BaseEntityAudit.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.Column;
 import jakarta.persistence.MappedSuperclass;
 import java.io.Serializable;
-import java.util.Date;
+import java.time.LocalDateTime;
 import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -31,11 +31,11 @@ public abstract class BaseEntityAudit extends BaseEntity implements Serializable
 
 	@CreationTimestamp
 	@Column(name = "created_at", updatable = false)
-	private Date createdAt;
+	private LocalDateTime createdAt;
 
 	@UpdateTimestamp
 	@Column(name = "updated_at")
-	private Date updatedAt;
+	private LocalDateTime updatedAt;
 
 	@Override
 	public boolean equals(Object o) {


### PR DESCRIPTION
- Added a dependency on com.fasterxml.jackson.datatype:jackson-datatype-jsr310 to support date and datetime formatting.
- Replaced usages of Date with LocalDateTime for better date and time handling.
- Configured Jackson ObjectMapper with custom serializers and deserializers for LocalDate and LocalDateTime.
- Defined DateTimeFormatter instances for date and datetime formatting.